### PR TITLE
permit skipping one or two letter days

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -20,6 +20,7 @@ function doGet() {
 function addEvents(
   calendarName,
   query,
+  frequency,
   title,
   guests,
   location,
@@ -155,6 +156,9 @@ function addEvents(
   // Track dates when events with title occur
   var date = {};
 
+  // Event counter
+  var eventIndex = 0;
+
   // Loop through each event found
   events.forEach(function (event) {
     var eventDate = event.getStartTime();
@@ -168,12 +172,15 @@ function addEvents(
 
   var firstEvent = true; // for first event, to which subsequent events will be chained
   var eventSeries = ""; // for chaining events
+  var indexKeep = query.length*(frequency-1); // start first date at this index
 
+  // every event will have the same first date
   var firstDate;
-  for (var k in date) {
-    firstDate = new Date(k);
-    break;
-  }
+  // for (var k in date) {
+    // firstDate = new Date(k);
+    // break;
+  // }
+  firstDate = new Date(Object.keys(date)[indexKeep]); // sort dictionary keys into an array, and select one at index
 
   var dateStartTime = new Date(
     firstDate.getFullYear(),
@@ -207,79 +214,84 @@ function addEvents(
 
     // function nested because it relies on many parameters
     function createEvent(calendar, includesHttp) {
-      if (firstEvent) {
-        if (includesHttp) {
-          if (startTime === "" && endTime === "") {
-            // make all-day event
-            eventSeries = calendar.createAllDayEventSeries(
-              title,
-              eventDate,
-              CalendarApp.newRecurrence().addDate(eventDate),
-              {
-                location: location,
-                description:
-                  '<a href="' + description + '" target="_blank" >Agenda</a>',
-                guests: guests,
-              }
-            );
+      if (eventIndex === indexKeep) {
+        indexKeep++;
+        if (indexKeep % query.length === 0) // jump every query.length
+          indexKeep = indexKeep + query.length*(frequency-1);
+        if (firstEvent) {
+          if (includesHttp) {
+            if (startTime === "" && endTime === "") {
+              // make all-day event
+              eventSeries = calendar.createAllDayEventSeries(
+                title,
+                eventDate,
+                CalendarApp.newRecurrence().addDate(eventDate),
+                {
+                  location: location,
+                  description:
+                    '<a href="' + description + '" target="_blank" >Agenda</a>',
+                  guests: guests,
+                }
+              );
+            } else {
+              // make regular event
+              eventSeries = calendar.createEventSeries(
+                title,
+                dateStartTime,
+                dateEndTime,
+                CalendarApp.newRecurrence().addDate(eventDate),
+                {
+                  location: location,
+                  description:
+                    '<a href="' + description + '" target="_blank" >Agenda</a>',
+                  guests: guests,
+                }
+              );
+            }
           } else {
-            // make regular event
-            eventSeries = calendar.createEventSeries(
-              title,
-              dateStartTime,
-              dateEndTime,
-              CalendarApp.newRecurrence().addDate(eventDate),
-              {
-                location: location,
-                description:
-                  '<a href="' + description + '" target="_blank" >Agenda</a>',
-                guests: guests,
-              }
-            );
+            if (startTime === "" && endTime === "") {
+              // make all-day event
+              eventSeries = calendar.createAllDayEventSeries(
+                title,
+                eventDate,
+                CalendarApp.newRecurrence().addDate(eventDate),
+                {
+                  location: location,
+                  description: description,
+                  guests: guests,
+                }
+              );
+            } else {
+              // make regular event
+              eventSeries = calendar.createEventSeries(
+                title,
+                dateStartTime,
+                dateEndTime,
+                CalendarApp.newRecurrence().addDate(eventDate),
+                {
+                  location: location,
+                  description: description,
+                  guests: guests,
+                }
+              );
+            }
           }
-        } else {
-          if (startTime === "" && endTime === "") {
-            // make all-day event
-            eventSeries = calendar.createAllDayEventSeries(
-              title,
-              eventDate,
-              CalendarApp.newRecurrence().addDate(eventDate),
-              {
-                location: location,
-                description: description,
-                guests: guests,
-              }
-            );
-          } else {
-            // make regular event
-            eventSeries = calendar.createEventSeries(
-              title,
-              dateStartTime,
-              dateEndTime,
-              CalendarApp.newRecurrence().addDate(eventDate),
-              {
-                location: location,
-                description: description,
-                guests: guests,
-              }
-            );
-          }
-        }
-        firstEvent = false;
-      } // chain subsequent event to first event
-      else {
-        if (startTime === "" && endTime === "") {
-          eventSeries.setRecurrence(
-            CalendarApp.newRecurrence().addDate(eventDate),
-            firstDate
-          );
-        }
+          firstEvent = false;
+        } // chain subsequent event to first event
         else {
-          eventSeries.setRecurrence(
-            CalendarApp.newRecurrence().addDate(eventDate),
-            dateStartTime,
-            dateEndTime
-          );
+          if (startTime === "" && endTime === "") {
+            eventSeries.setRecurrence(
+              CalendarApp.newRecurrence().addDate(eventDate),
+              firstDate
+            );
+          }
+          else {
+            eventSeries.setRecurrence(
+              CalendarApp.newRecurrence().addDate(eventDate),
+              dateStartTime,
+              dateEndTime
+            );
+          }
         }
       }
       return null;
@@ -287,6 +299,7 @@ function addEvents(
 
     // Log which events were added
     Logger.log("Created a new event on " + eventDate);
+    eventIndex++;
   }
   return "Events created! Go to your Google Calendar...";
 }

--- a/Index.html
+++ b/Index.html
@@ -31,6 +31,9 @@
         -webkit-box-sizing: border-box;
         box-sizing: border-box; /* compatibility */
       }
+      input[type="number"] {
+        width: 2em;
+      }
       select,
       input,
       textarea,
@@ -43,6 +46,7 @@
       input[type="submit"],
       text,
       div[id="section"],
+      div[id="inline"],
       div[id="issues"] {
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
           Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
@@ -128,6 +132,20 @@
         
         <text>Letter day on which you want to create an event</text>
         <!-- prefilled for clarity -->
+        <br /><br />
+
+        <!-- <label for="frequency">Frequency:</label><br> -->
+        <div id="inline">
+          Every&nbsp; <input
+            type="number"
+            id="frequency"
+            name="frequency"
+            value="1"
+            min="1"
+            max="3"
+          /> &nbsp;letter day(s)
+        </div>
+        <text>Skip one or two letter days</text>
         <br /><br />
       </div>
 
@@ -298,6 +316,7 @@
 
           var calendarName = document.getElementById("calendarName").value;
           var query = [...document.querySelectorAll('input[name=query]:checked')].map(({value}) => value);
+          var frequency = document.getElementById("frequency").value;
           var title = document.getElementById("title").value;
           var guests = document.getElementById("guests").value;
           var location = document.getElementById("location").value;
@@ -317,6 +336,7 @@
             .addEvents(
               calendarName,
               query,
+              frequency,
               title,
               guests,
               location,


### PR DESCRIPTION
@CAISSF this pull request enables users the ability to skip one or two letter days

I tested it with your HEAD commit, and it worked for me.
See how it works for you :)

Note: `firstDate`, to which all events are chained, now depends on the `query.length` and `frequency`. The more letter days users select (J, I, A, ...) and the less frequent they opt to create them (e.g., every 2 or 3 letter days), then the later the first date.